### PR TITLE
[FIX] 타임리프 관련 레이아웃 깨짐 yml 파일 수정

### DIFF
--- a/arterium/src/main/resources/application.yml
+++ b/arterium/src/main/resources/application.yml
@@ -4,8 +4,6 @@ spring:
       enabled: true
     restart:
       enabled: true
-  mvc:
-    static-path-pattern: /static/**
   thymeleaf:
     check-template-location: true
     prefix: classpath:/templates/
@@ -35,6 +33,9 @@ spring:
         dialect: org.hibernate.dialect.MySQL8Dialect
     hibernate:
       ddl-auto: none
+  web:
+    resources:
+      static-locations: classpath:/META-INF/resources/,classpath:/resources/,classpath:/static/,classpath:/public/
 
 #  web:
 #    resources:


### PR DESCRIPTION
## 수정 내용
- application.yml 파일 수정
-   mvc:
      `static-path-pattern: /static/**`
      를

 ` web: resources: static-locations: classpath:/META-INF/resources/,classpath:/resources/,classpath:/static/,classpath:/public/`

로 수정
- spring.mvc.static-path-pattern 설정은 SpringBoot 2.4 이상에서는 설정이 제거됨